### PR TITLE
Enable copy-pr-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,1 @@
+enabled: true


### PR DESCRIPTION
This PR enables the copy-pr-bot, which allows organization members to trigger CI on PRs by leaving an `/ok to test <SHA>` comment.