### PR TITLE
fix : package links in github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - "pull-request/[0-9]+"
 env:
-  TRT_RTX_FILENAME: TensorRT-RTX-1.2.0.44-Linux-x86_64-cuda-12.9-Release-external.tar.gz
+  TRT_RTX_FILENAME: TensorRT-RTX-1.2.0.54-Linux-x86_64-cuda-12.9-Release-external.tar.gz
   TRTRTX_INSTALL_DIR: /opt/tensorrt_rtx
   BUILD_DIR: build
   UV_PROJECT: .github/workflows/

--- a/.github/workflows/utils.py
+++ b/.github/workflows/utils.py
@@ -25,7 +25,7 @@ import requests
 # Shared constants
 TRT_RTX_BASE_URL = "https://developer.nvidia.com/downloads/trt/rtx_sdk/secure/1.2/"
 TRT_RTX_FILENAME = os.environ.get(
-    "TRT_RTX_FILENAME", "TensorRT-RTX-1.2.0.44-Linux-x86_64-cuda-12.9-Release-external.tar.gz"
+    "TRT_RTX_FILENAME", "TensorRT-RTX-1.2.0.54-Linux-x86_64-cuda-12.9-Release-external.tar.gz"
 )
 TRTRTX_INSTALL_DIR = os.environ.get("TRTRTX_INSTALL_DIR", "/opt/tensorrt_rtx")
 BUILD_DIR = os.environ.get("BUILD_DIR", "build")


### PR DESCRIPTION
This MR updates stale package names in Github CI to the latest available ones. 